### PR TITLE
Scraper Patch

### DIFF
--- a/countyscraper.py
+++ b/countyscraper.py
@@ -1,6 +1,10 @@
 from bs4 import BeautifulSoup
 import json
 import requests
+import sys
+
+def FormatAPN(apn):
+	return '{0}-{1}-{2}-{3}-{4}-{5}-{6}-{7}'.format(apn[0:2], apn[2:5], apn[5:7], apn[7:9], apn[9:11], apn[11], apn[12:14], apn[14:len(apn)])
 
 def ExtractJSONAPNS(fileloc):
 	file = open(fileloc, 'r')
@@ -31,7 +35,7 @@ def ExtractJSONAPNS(fileloc):
 		apn = parcel.strip('JA')
 
 		if len(apn) is 17:
-			apndict[parcel] = '{0}-{1}-{2}-{3}-{4}-{5}-{6}-{7}'.format(apn[0:2], apn[2:5], apn[5:7], apn[7:9], apn[9:11], apn[11], apn[12:14], apn[14:len(apn)])
+			apndict[parcel] = FormatAPN(apn)
 			apncount += 1
 
 	del extractedJSON[:]
@@ -128,11 +132,37 @@ def ScrapeIncentives(html):
 
 	return incentivesDict
 
+def Help():
+	return "Jackson County Parcel Data Scraper\n \
+			args: \n \
+			--help : Prints this help statement \n \
+			--file <file name> : scrapes all data from the json file listing APNS and outputs to a JSON \n \
+			--apn <apn1>, <apn2>, ..., <apnN> : scrapes data for list of apns provided and outputs to a JSON \n"
 
 def main():
 	baseURL = "http://maps.jacksongov.org/PropertyReport/PropertyReport.cfm?pid="
 
-	apns = ExtractJSONAPNS("apns.json")
+	args = sys.argv
+	apns = dict()
+
+	if len(args) > 1:
+		if args[1] == "--help":
+			sys.exit(Help())
+		elif args[1] == "--file":
+			apns = ExtractJSONAPNS(args[2])
+		elif args[1] == "--apn":
+			for apn in args[2:len(args)]:
+				usableapn = apn.strip('JA')
+				if len(usableapn) is 17:
+					apns[apn] = FormatAPN(usableapn)
+		else:
+			sys.exit("Invalid argument provided for list of commands use --help")
+				
+	else:
+		sys.exit("No arguments provided for list of commands use --help")
+
+	if len(apns) is 0:
+		sys.exit("No valid APNs were provided")
 
 	parceldict = dict()
 


### PR DESCRIPTION
I enabled command line arguments for the scraper

to use a list of apns:
`countyscraper.py --apn <apn1> <apn2> ... <apnN>`
for example:
`countyscraper.py --apn JA46220141400000000` outputs 

`{"JA46220141400000000": {"Incentives": {"Enterprise Zone": "Midtown to RG", "Capital Improvement Project": "Not within a capital improvement project", "Community Improvement District": "NA", "Neighborhood Improvement Program": "NA", "Neighborhood Improvement District": "NA", "Urban Renewal District": "NA"}, "Property Values": {"Tax Year2015": {"Assessed Value Total": 4852, "Taxable Value Total": 4851, "Market Value Total": 25534}, "Tax Year2014": {"Assessed Value Total": 4852, "Taxable Value Total": 4851, "Market Value Total": 25534}, "Tax Year2013": {"Assessed Value Total": 4852, "Taxable Value Total": 4851, "Market Value Total": 25534}, "Tax Year2012": {"Assessed Value Total": 4852, "Taxable Value Total": 4851, "Market Value Total": 25534}, "Tax Year2011": {"Assessed Value Total": 4852, "Taxable Value Total": 4852, "Market Value Total": 25534}}, "Exemptions": ["NA"]}}`

Tested in Python 2.7.9
