### PR TITLE
Upgraded to postgresql-9.3-postgis-2.2

### DIFF
--- a/INSTALL/README.md
+++ b/INSTALL/README.md
@@ -128,6 +128,36 @@ CREATE EXTENSION postgis_sfcgal;
 CREATE EXTENSION address_standardizer;
 ```
 
+### Verifiy Install
+
+* Postgres Server: run `pg_config --version`
+* Postgres Client: run `psql --version`
+* GDB with ESRI File GDB: run `ogrinfo --formats | grep -i OpenFileGDB` you should see `"OpenFileGDB" (readonly)`
+* FWD with ESRI file GDB: run `ogr_fdw_info -f | grep -i OpenFileGDB` you should see `GDAL 2.1.0, released 2016/04/25`
+* GDAL: run `ogr2ogr --version`
+* Postgres extensions: in `psql run
+
+````
+    SELECT PostGIS_full_version();
+    SELECT PostGIS_Lib_Version();
+````
+
+You should see
+
+Package        |  Virtual Box                            | 
+-------------- | --------------------------------------- | 
+Postgres Sever | PostgreSQL 9.3.13                       | 
+Postgres Client| psql (PostgreSQL) 9.3.13                | 
+-------------- | --------------------------------------- | 
+PostGIS        | OSTGIS="2.1.2 r12389"                   | 
+               | GEOS="3.4.2-CAPI-1.8.2 r3921"           | 
+               | PROJ="Rel. 4.8.0, 6 March 2012"         | 
+               | GDAL="GDAL 1.11.2, released 2015/02/10" | 
+               | LIBXML="2.9.1" LIBJSON="UNKNOWN" RASTER | 
+
+
+ 
+
 # Installing `gh-pages` and Jekyll
 Do this above the `address-api` directory, so both are at the same level.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,26 +16,39 @@
     echo "rvm use 2.2.3" >> .bashrc
 
     sudo apt-get update -y
+    sudo sudo apt-get autoclean -y
+    sudo dpkg --configure -a 
+    sudo apt-get -u dist-upgrade
+    sudo sudo apt-get autoclean -y
+
 
     # Install some friends
     sudo apt-get -y install unzip wget git make
 
+    # Used for postgres and  GDAL/OGR
+
+    sudo apt-get install -y python-software-properties
+    sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get update
+
     # install postgres
-    sudo apt-get -y install postgresql postgresql-contrib libpq-dev postgresql-9.3-postgis-2.1 redis-server
+    sudo apt-get -y install postgresql postgresql-contrib libpq-dev postgresql-9.3-postgis-2.2 redis-server
+
+#
+# ------------
+#
+
 
     ### support PostGres Foreign data wrapers
 
     # Install GDAL/OGR
-    apt-get install -y python-software-properties
-    add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get update
-    apt-get install -y gdal-bin
+    sudo apt-get install -y gdal-bin
 
     # From previous postgresql install line
-    apt-get install -y libgdal-dev
+    sudo apt-get install -y libgdal-dev
 
     # since we do not have pgxs.mk needed for making pgsql-ogr-fdw in the next step
     # WARNING:  this may cause issues
-    apt-get install -y --force-yes postgresql-server-dev-9.3
+    sudo apt-get install -y --force-yes postgresql-server-dev-9.3
 
     (
         cd /tmp
@@ -112,7 +125,8 @@ fi
 EOF
 )
 
-   echo "${OGR}" > /etc/profile.d/ogr.sh
+   echo "${OGR}" > /tmp/ogr.sh
+   sudo mv /tmp/ogr.sh /etc/profile.d/ogr.sh
 
 
     ### Apache + PHP ###
@@ -188,6 +202,8 @@ EOF
     cd /etc/apache2/sites-enabled
     sudo ln -s ../sites-available/002-dev-api.conf .
 
+
+    sudo rm /etc/apache2/sites-enabled/000-default.conf
 
     cd /var/www
     composer update

--- a/data/scripts/fix_ownerships.psql
+++ b/data/scripts/fix_ownerships.psql
@@ -17,7 +17,6 @@ alter table  neighborhoods_id_seq        OWNER TO c4kc;
 alter table  tmp_kcmo_all_addresses      OWNER TO c4kc;
 alter table  tmp_kcmo_all_addresses_id_seq  OWNER TO c4kc;
 
-\d
 
 \c code4kc
 
@@ -35,4 +34,4 @@ alter table  address_spatial.mo_kc_city_council_districts_2012   OWNER TO c4kc;
 alter table  address_spatial.mo_kc_city_neighborhoods            OWNER TO c4kc;
 alter table  address_spatial.paul                                OWNER TO c4kc;
 
-\dt *.*
+


### PR DESCRIPTION
- Upgraded from postgresql-9.3-postgis-2.1 to postgresql-9.3-postgis-2.2
- Now all command in bootstrap.sh have sudo in front of them,
  helps with build of server.
- Removed \d and \dt from fix_ownerships.psql now no user input is required
- Added notes to verify that GDAL, OGR, and FDW are installed in INSTALL/README.md 
